### PR TITLE
refactor(dashboard): simplify Sidebar props and sync tab state with URL

### DIFF
--- a/src/components/views/dashboard/components/Sidebar.tsx
+++ b/src/components/views/dashboard/components/Sidebar.tsx
@@ -2,11 +2,11 @@
 
 import { User, Car, FileText, Crown, PlusCircle } from "lucide-react";
 import { useUserData } from "@/hooks/useUserData";
-import { Dispatch, SetStateAction, useState } from "react";
+import { useState } from "react";
 
 interface SidebarProps {
 	activeTab: string;
-	setActiveTab: Dispatch<SetStateAction<string>>;
+	setActiveTab: (tab: string) => void;
 }
 
 export default function Sidebar({ activeTab, setActiveTab }: SidebarProps) {

--- a/src/components/views/dashboard/dashboardView.tsx
+++ b/src/components/views/dashboard/dashboardView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import Sidebar from "./components/Sidebar";
 import ProfileContent from "./components/ProfileContent";
 import VehiclesContent from "./components/VehiclesContent";
@@ -10,8 +11,32 @@ import PublishVehicleContent from "./components/PublishVehicleContent";
 import { useUserData } from "@/hooks/useUserData";
 
 export default function Dashboard() {
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const tabParam = searchParams.get("tab");
 	const [activeTab, setActiveTab] = useState("profile");
 	const { loading } = useUserData();
+
+	useEffect(() => {
+		if (tabParam) {
+			const validTabs = [
+				"profile",
+				"vehicles",
+				"publications",
+				"register-vehicle",
+				"publish-vehicle",
+				"vip",
+			];
+			if (validTabs.includes(tabParam)) {
+				setActiveTab(tabParam);
+			}
+		}
+	}, [tabParam]);
+
+	const handleTabChange = (tab: string) => {
+		setActiveTab(tab);
+		router.push(`/dashboard?tab=${tab}`);
+	};
 
 	const renderContent = () => {
 		if (loading) {
@@ -52,7 +77,7 @@ export default function Dashboard() {
 
 	return (
 		<div className='flex min-h-screen bg-white'>
-			<Sidebar activeTab={activeTab} setActiveTab={setActiveTab} />
+			<Sidebar activeTab={activeTab} setActiveTab={handleTabChange} />
 			<main className='flex-1 p-6 md:p-8'>{renderContent()}</main>
 		</div>
 	);


### PR DESCRIPTION
Simplify the `setActiveTab` prop in the Sidebar component by replacing `Dispatch<SetStateAction<string>>` with a simpler function type. Additionally, sync the active tab state with the URL using `useSearchParams` and `useRouter` to ensure the tab persists across page reloads and navigation.