### PR TITLE
feat(dashboard): add mobile navigation menu for dashboard tabs

### DIFF
--- a/src/components/views/dashboard/dashboardView.tsx
+++ b/src/components/views/dashboard/dashboardView.tsx
@@ -9,13 +9,14 @@ import PublicationsContent from "./components/PostContent";
 import RegisterVehicleContent from "./components/RegisterVehicleContent";
 import PublishVehicleContent from "./components/PublishVehicleContent";
 import { useUserData } from "@/hooks/useUserData";
+import { User, Car, FileText, Crown, PlusCircle } from "lucide-react";
 
 export default function Dashboard() {
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const tabParam = searchParams.get("tab");
 	const [activeTab, setActiveTab] = useState("profile");
-	const { loading } = useUserData();
+	const { loading, userData } = useUserData();
 
 	useEffect(() => {
 		if (tabParam) {
@@ -75,10 +76,42 @@ export default function Dashboard() {
 		}
 	};
 
+	const menuItems = [
+		{ id: "profile", label: "Perfil", icon: User },
+		{ id: "vehicles", label: "Vehículos", icon: Car },
+		{ id: "publications", label: "Publicaciones", icon: FileText },
+		{ id: "register-vehicle", label: "Registrar", icon: PlusCircle },
+		{ id: "vip", label: "VIP", icon: Crown },
+	];
+
 	return (
 		<div className='flex min-h-screen bg-white'>
 			<Sidebar activeTab={activeTab} setActiveTab={handleTabChange} />
-			<main className='flex-1 p-6 md:p-8'>{renderContent()}</main>
+			<main className='flex-1 p-6 md:p-8 pb-20 md:pb-8'>
+				{renderContent()}
+			</main>
+
+			<div className='fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 md:hidden z-50'>
+				<div className='flex justify-around items-center h-16'>
+					{menuItems.map((item) => (
+						<button
+							key={item.id}
+							onClick={() => handleTabChange(item.id)}
+							className={`flex flex-col items-center justify-center w-full h-full transition-colors ${
+								activeTab === item.id
+									? "text-principal-blue"
+									: "text-gray-500 hover:text-principal-blue"
+							}`}>
+							<item.icon
+								className={`w-5 h-5 ${
+									activeTab === item.id ? "scale-110" : ""
+								}`}
+							/>
+							<span className='text-xs mt-1'>{item.label}</span>
+						</button>
+					))}
+				</div>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Introduce a new mobile navigation menu at the bottom of the dashboard view to improve accessibility and user experience on smaller screens. The menu includes icons and labels for each tab, enhancing navigation clarity. Additionally, the `userData` property is now destructured from the `useUserData` hook for potential future use.