### PR TITLE
feat(profile): add profile image upload functionality

### DIFF
--- a/src/components/views/dashboard/components/Sidebar.tsx
+++ b/src/components/views/dashboard/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { User, Car, FileText, Crown, PlusCircle } from "lucide-react";
 import { useUserData } from "@/hooks/useUserData";
 import { useState } from "react";
+import Image from "next/image";
 
 interface SidebarProps {
 	activeTab: string;
@@ -25,12 +26,36 @@ export default function Sidebar({ activeTab, setActiveTab }: SidebarProps) {
 		{ id: "vip", label: "VIP", icon: Crown },
 	];
 
+	const getInitials = (name: string) => {
+		return name
+			.split(" ")
+			.map((part) => part[0])
+			.join("")
+			.toUpperCase()
+			.substring(0, 2);
+	};
+
 	return (
 		<aside className='w-64 border-r border-gray-200 bg-white hidden md:block'>
 			<div className='p-6'>
 				<div className='flex items-center gap-3 mb-8'>
-					<div className='w-10 h-10 rounded-full bg-principal-blue flex items-center justify-center text-white font-bold transition-transform duration-300 hover:scale-110'>
-						{userData?.name ? userData.name.charAt(0) : "U"}
+					<div className='w-10 h-10 rounded-full bg-principal-blue flex items-center justify-center text-white font-bold transition-transform duration-300 hover:scale-110 overflow-hidden'>
+						{userData?.image ? (
+							<div className='relative w-full h-full'>
+								<Image
+									src={userData.image}
+									alt={userData.name || "Usuario"}
+									fill
+									className='object-cover'
+								/>
+							</div>
+						) : (
+							<>
+								{userData?.name
+									? getInitials(userData.name)
+									: "U"}
+							</>
+						)}
 					</div>
 					<div>
 						<h2 className='font-semibold'>

--- a/src/hooks/useUserData.tsx
+++ b/src/hooks/useUserData.tsx
@@ -6,6 +6,8 @@ import {
 	updateUserData,
 	UserData,
 	UpdateUserData,
+	uploadUserProfileImage,
+	deleteUserAccount,
 } from "@/services/api.service";
 import { useAuthStore } from "@/context/AuthContext";
 import { useRouter } from "next/navigation";
@@ -94,6 +96,28 @@ export const useUserData = () => {
 		}
 	};
 
+	const uploadProfileImage = async (file: File) => {
+		if (!isAuthenticated || !token)
+			return { success: false, error: "No autenticado" };
+
+		try {
+			const response = await uploadUserProfileImage(file);
+			if (!response || !response.data) {
+				throw new Error("Respuesta inválida del servidor");
+			}
+			
+			await fetchUserData();
+			return { success: true };
+		} catch (error: any) {
+			const errorMessage =
+				error.message || "Error al subir la imagen de perfil";
+			return {
+				success: false,
+				error: errorMessage,
+			};
+		}
+	};
+
 	const refetch = () => {
 		if (isAuthenticated && token) {
 			fetchUserData();
@@ -108,7 +132,7 @@ export const useUserData = () => {
 		setError(null);
 
 		try {
-			await deleteAccount();
+			await deleteUserAccount();
 			removeAuthToken();
 			router.push("/login");
 			return { success: true };
@@ -134,5 +158,6 @@ export const useUserData = () => {
 		updateUser,
 		deleteAccount,
 		refetch,
+		uploadProfileImage,
 	};
 };

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -105,6 +105,7 @@ export interface UserData {
 	city?: string;
 	address?: string;
 	role?: string;
+	image?: string;
 	posts?: {
 		id: string;
 		postDate: string;
@@ -150,6 +151,39 @@ export const updateUserData = async (
 			error.response?.data?.message ||
 			error.message ||
 			"Error al actualizar datos del usuario";
+		throw new Error(errorMsg);
+	}
+};
+
+export interface UploadProfileImageResponse {
+	data: {
+		image: string;
+	};
+	message: string;
+}
+
+export const uploadUserProfileImage = async (
+	file: File
+): Promise<UploadProfileImageResponse> => {
+	try {
+		const formData = new FormData();
+		formData.append('image', file);
+		
+		const response = await http.patch<UploadProfileImageResponse>(
+			"/files/user-profile",
+			formData,
+			{
+				headers: {
+					'Content-Type': 'multipart/form-data',
+				},
+			}
+		);
+		return response.data;
+	} catch (error: any) {
+		const errorMsg =
+			error.response?.data?.message ||
+			error.message ||
+			"Error al subir la imagen de perfil";
 		throw new Error(errorMsg);
 	}
 };


### PR DESCRIPTION
The changes include:
- Adding a new `image` field to the `UserData` interface.
- Implementing the `uploadUserProfileImage` API service.
- Integrating the upload functionality into the `useUserData` hook.
- Updating the UI components (`Sidebar`, `ProfileContent`, `UserData`) to display and handle profile images.